### PR TITLE
解决默认编译级别为11的问题

### DIFF
--- a/Chapter 2/datasource-demo/pom.xml
+++ b/Chapter 2/datasource-demo/pom.xml
@@ -53,6 +53,15 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
工程导入后，默认编译级别11，调整为更普遍的编译级别8